### PR TITLE
Remove (almost all) provider specifics from configure.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+venv/
 
 # C extensions
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 __pycache__/
 *.py[cod]
 *$py.class
-venv/
 
 # C extensions
 *.so

--- a/gmab/providers/aws.py
+++ b/gmab/providers/aws.py
@@ -1,9 +1,12 @@
 # gmab/providers/aws.py
 
 import boto3
+import click
+import functools
 import random
 import string
 import time
+from abc import abstractmethod
 from pathlib import Path
 from gmab.providers.base import ProviderBase
 
@@ -25,6 +28,45 @@ class AWSProvider(ProviderBase):
         )
         self.ec2 = self.session.client('ec2')
         self.ec2_resource = self.session.resource('ec2')
+
+    @staticmethod
+    @abstractmethod
+    def get_default_config():
+        return {
+            "access_key": "",
+            "secret_key": "",
+            "default_region": "eu-west-1",
+            "default_image": "ami-0574da719dca65348",
+            "default_type": "t3.micro"
+        }
+
+    @staticmethod
+    @abstractmethod
+    def get_config_prompts(provider_config):
+        config = {}
+        config['access_key'] = functools.partial(click.prompt,
+            "Access Key",
+            default=provider_config.get('access_key', ''),
+            hide_input=False
+        )
+        config['secret_key'] = functools.partial(click.prompt,
+            "Secret Key",
+            default=provider_config.get('secret_key', ''),
+            hide_input=False
+        )
+        config['default_region'] = functools.partial(click.prompt,
+            "Default region",
+            default=provider_config.get('default_region', AWSProvider.get_default_config()['default_region'])
+        )
+        config['default_image'] = functools.partial(click.prompt,
+            "Default image",
+            default=provider_config.get('default_image', AWSProvider.get_default_config()['default_image'])
+        )
+        config['default_type'] = functools.partial(click.prompt,
+            "Default instance type",
+            default=provider_config.get('default_type', AWSProvider.get_default_config()['default_type'])
+        )
+        return config
 
     def get_or_create_vpc(self):
         """Get existing gmab VPC or create a new one."""

--- a/gmab/providers/aws.py
+++ b/gmab/providers/aws.py
@@ -6,7 +6,6 @@ import functools
 import random
 import string
 import time
-from abc import abstractmethod
 from pathlib import Path
 from gmab.providers.base import ProviderBase
 
@@ -30,7 +29,6 @@ class AWSProvider(ProviderBase):
         self.ec2_resource = self.session.resource('ec2')
 
     @staticmethod
-    @abstractmethod
     def get_default_config():
         return {
             "access_key": "",
@@ -41,7 +39,6 @@ class AWSProvider(ProviderBase):
         }
 
     @staticmethod
-    @abstractmethod
     def get_config_prompts(provider_config):
         config = {}
         config['access_key'] = functools.partial(click.prompt,

--- a/gmab/providers/base.py
+++ b/gmab/providers/base.py
@@ -21,6 +21,10 @@ class ProviderBase(ABC):
         """
         self.provider_cfg = provider_cfg
         self.provider_name = None  # Will be set by the factory
+    
+    @staticmethod
+    def get_config_prompts():
+        return []
 
     @abstractmethod
     def spawn_instance(self, image=None, region=None, ssh_key_path=None, lifetime_minutes=None):

--- a/gmab/providers/base.py
+++ b/gmab/providers/base.py
@@ -23,7 +23,13 @@ class ProviderBase(ABC):
         self.provider_name = None  # Will be set by the factory
     
     @staticmethod
-    def get_config_prompts():
+    @abstractmethod
+    def get_default_config():
+        return 
+
+    @staticmethod
+    @abstractmethod
+    def get_config_prompts(provider_config):
         return []
 
     @abstractmethod

--- a/gmab/providers/hetzner.py
+++ b/gmab/providers/hetzner.py
@@ -6,7 +6,6 @@ import requests
 import random
 import string
 import time
-from abc import abstractmethod
 from pathlib import Path
 from gmab.providers.base import ProviderBase
 
@@ -113,7 +112,6 @@ class HetznerProvider(ProviderBase):
             raise Exception(f"Failed to get or create SSH key: {str(e)}")
         
     @staticmethod
-    @abstractmethod
     def get_default_config():
         return {
             "api_key": "",
@@ -123,7 +121,6 @@ class HetznerProvider(ProviderBase):
         }
     
     @staticmethod
-    @abstractmethod
     def get_config_prompts(provider_config):
         config = {}
         config['api_key'] = functools.partial(click.prompt,

--- a/gmab/providers/hetzner.py
+++ b/gmab/providers/hetzner.py
@@ -1,9 +1,12 @@
 # gmab/providers/hetzner.py
 
+import click
+import functools
 import requests
 import random
 import string
 import time
+from abc import abstractmethod
 from pathlib import Path
 from gmab.providers.base import ProviderBase
 
@@ -108,6 +111,39 @@ class HetznerProvider(ProviderBase):
             raise Exception(f"Network error when managing SSH keys: {str(e)}")
         except Exception as e:
             raise Exception(f"Failed to get or create SSH key: {str(e)}")
+        
+    @staticmethod
+    @abstractmethod
+    def get_default_config():
+        return {
+            "api_key": "",
+            "default_region": "nbg1",
+            "default_image": "ubuntu-22.04",
+            "default_type": "cpx11"
+        }
+    
+    @staticmethod
+    @abstractmethod
+    def get_config_prompts(provider_config):
+        config = {}
+        config['api_key'] = functools.partial(click.prompt,
+            "API Key",
+            default=provider_config.get('api_key', ''),
+            hide_input=False
+        )
+        config['default_region'] = functools.partial(click.prompt,
+            "Default region",
+            default=provider_config.get('default_region', HetznerProvider.get_default_config()['default_region'])
+        )
+        config['default_image'] = functools.partial(click.prompt,
+            "Default image",
+            default=provider_config.get('default_image', HetznerProvider.get_default_config()['default_image'])
+        )
+        config['default_type'] = functools.partial(click.prompt,
+            "Default instance type",
+            default=provider_config.get('default_type', HetznerProvider.get_default_config()['default_type'])
+        )
+        return config
 
     def spawn_instance(self, image=None, region=None, ssh_key_path=None, lifetime_minutes=None):
         """

--- a/gmab/providers/linode.py
+++ b/gmab/providers/linode.py
@@ -6,7 +6,6 @@ import requests
 import random
 import string
 import time
-from abc import abstractmethod
 from pathlib import Path
 from gmab.providers.base import ProviderBase
 
@@ -20,7 +19,6 @@ class LinodeProvider(ProviderBase):
     """
 
     @staticmethod
-    @abstractmethod
     def get_default_config():
         return {
             "api_key": "",
@@ -31,7 +29,6 @@ class LinodeProvider(ProviderBase):
         }
 
     @staticmethod
-    @abstractmethod
     def get_config_prompts(provider_config):
         config = {}
         config['api_key'] = functools.partial(click.prompt,

--- a/gmab/providers/linode.py
+++ b/gmab/providers/linode.py
@@ -1,9 +1,12 @@
 ﻿# gmab/providers/linode.py
 
+import click
+import functools
 import requests
 import random
 import string
 import time
+from abc import abstractmethod
 from pathlib import Path
 from gmab.providers.base import ProviderBase
 
@@ -15,6 +18,45 @@ class LinodeProvider(ProviderBase):
     """
     Provider implementation for Linode.
     """
+
+    @staticmethod
+    @abstractmethod
+    def get_default_config():
+        return {
+            "api_key": "",
+            "default_region": "nl-ams",
+            "default_image": "linode/ubuntu22.04",
+            "default_type": "g6-nanode-1",
+            "default_root_pass": ""
+        }
+
+    @staticmethod
+    @abstractmethod
+    def get_config_prompts(provider_config):
+        config = {}
+        config['api_key'] = functools.partial(click.prompt,
+            "API Key",
+            default=provider_config.get('api_key', ''),
+            hide_input=False
+        )
+        config['default_region'] = functools.partial(click.prompt,
+            "Default region",
+            default=provider_config.get('default_region', LinodeProvider.get_default_config()['default_region'])
+        )
+        config['default_image'] = functools.partial(click.prompt,
+            "Default image",
+            default=provider_config.get('default_image', LinodeProvider.get_default_config()['default_image'])
+        )
+        config['default_type'] = functools.partial(click.prompt,
+            "Default instance type",
+            default=provider_config.get('default_type', LinodeProvider.get_default_config()['default_type'])
+        )
+        config['default_root_pass'] = functools.partial(click.prompt,
+            "Default root password",
+            default=provider_config.get('default_root_pass', ''),
+            hide_input=False
+        )
+        return config
 
     def spawn_instance(self, image=None, region=None, ssh_key_path=None, lifetime_minutes=None):
         """

--- a/gmab/utils/config_loader.py
+++ b/gmab/utils/config_loader.py
@@ -4,6 +4,7 @@ import json
 import os
 from pathlib import Path
 from gmab.utils.paths import get_config_file_path, ensure_config_dir_exists
+from gmab.providers import *
 
 # Default configurations
 DEFAULT_GENERAL_CONFIG = {
@@ -12,27 +13,11 @@ DEFAULT_GENERAL_CONFIG = {
     "default_provider": "linode"
 }
 
+# TODO: Any usage of DEFAULT_PROVIDERS_CONFIG should be replaced by a function
 DEFAULT_PROVIDERS_CONFIG = {
-    "linode": {
-        "api_key": "",
-        "default_region": "nl-ams",
-        "default_image": "linode/ubuntu22.04",
-        "default_type": "g6-nanode-1",
-        "default_root_pass": ""
-    },
-    "aws": {
-        "access_key": "",
-        "secret_key": "",
-        "default_region": "eu-west-1",
-        "default_image": "ami-0574da719dca65348",
-        "default_type": "t3.micro"
-    },
-    "hetzner": {
-        "api_key": "",
-        "default_region": "nbg1",
-        "default_image": "ubuntu-22.04",
-        "default_type": "cpx11"
-    }
+    "linode": LinodeProvider.get_default_config(),
+    "aws": AWSProvider.get_default_config(),
+    "hetzner": AWSProvider.get_default_config(),
 }
 
 class ConfigNotFoundError(Exception):

--- a/tests/commands/test_configure.py
+++ b/tests/commands/test_configure.py
@@ -1,0 +1,26 @@
+import unittest
+
+from gmab.providers import *
+
+
+class TestConfigure(unittest.TestCase):
+    def assertAllIn(self, keys, dictionary):
+        for key in keys:
+            self.assertIn(key, dictionary)
+
+
+    def test_provider_configs(self):
+        # AWS
+        aws_keys = ['access_key', 'secret_key', 'default_region', 'default_image', 'default_type']
+        aws_config = AWSProvider.get_config_prompts()
+        self.assertAllIn(aws_keys, aws_config)
+
+        # Linode
+        linode_keys = ['api_key', 'default_region', 'default_image', 'default_type', 'default_root_pass']
+        linode_config = LinodeProvider.get_config_prompts()
+        self.assertAllIn(linode_keys, linode_config)
+
+        # Hetzner
+        hetzner_keys = ['api_key', 'default_region', 'default_image', 'default_type']
+        hetzner_config = HetznerProvider.get_config_prompts()
+        self.assertAllIn(hetzner_keys, hetzner_config)

--- a/tests/commands/test_configure.py
+++ b/tests/commands/test_configure.py
@@ -24,3 +24,9 @@ class TestConfigure(unittest.TestCase):
         hetzner_keys = ['api_key', 'default_region', 'default_image', 'default_type']
         hetzner_config = HetznerProvider.get_config_prompts({})
         self.assertAllIn(hetzner_keys, hetzner_config)
+
+
+    def test_provider_configurations(self):
+        aws_provider = AWSProvider({})
+        linode_provider = LinodeProvider({})
+        hetzner_provider = HetznerProvider({"api_key": "yes"})

--- a/tests/commands/test_configure.py
+++ b/tests/commands/test_configure.py
@@ -24,8 +24,3 @@ class TestConfigure(unittest.TestCase):
         hetzner_keys = ['api_key', 'default_region', 'default_image', 'default_type']
         hetzner_config = HetznerProvider.get_config_prompts({})
         self.assertAllIn(hetzner_keys, hetzner_config)
-
-
-    def test_configure_provider(self):
-        from gmab.commands import configure
-        configure.configure_provider("aws", {})

--- a/tests/commands/test_configure.py
+++ b/tests/commands/test_configure.py
@@ -12,15 +12,20 @@ class TestConfigure(unittest.TestCase):
     def test_provider_configs(self):
         # AWS
         aws_keys = ['access_key', 'secret_key', 'default_region', 'default_image', 'default_type']
-        aws_config = AWSProvider.get_config_prompts()
+        aws_config = AWSProvider.get_config_prompts({})
         self.assertAllIn(aws_keys, aws_config)
 
         # Linode
         linode_keys = ['api_key', 'default_region', 'default_image', 'default_type', 'default_root_pass']
-        linode_config = LinodeProvider.get_config_prompts()
+        linode_config = LinodeProvider.get_config_prompts({})
         self.assertAllIn(linode_keys, linode_config)
 
         # Hetzner
         hetzner_keys = ['api_key', 'default_region', 'default_image', 'default_type']
-        hetzner_config = HetznerProvider.get_config_prompts()
+        hetzner_config = HetznerProvider.get_config_prompts({})
         self.assertAllIn(hetzner_keys, hetzner_config)
+
+
+    def test_configure_provider(self):
+        from gmab.commands import configure
+        configure.configure_provider("aws", {})


### PR DESCRIPTION
This PR

- Partly addresses #1 and removes almost all provider specifics from configure.py (validation is another can of worms)
- Sets up unit tests (run with `python -m unittest`)
- Tests for changes of this PR

Since there is no general test coverage (issue #4) **please do some manual smoke testing before merging**.

Feel free to comment if there are any regressions.